### PR TITLE
Fix FSIconCard default iconColor & FSCard border-color

### DIFF
--- a/dev/storybook/src/stories/shared/tiles/UserOrganisation.stories.ts
+++ b/dev/storybook/src/stories/shared/tiles/UserOrganisation.stories.ts
@@ -19,17 +19,20 @@ export const Variations: Story = {
     args: {
       values: [{
         id: "1",
+        imageId: "1",
         name: "Jean-Michel Quelqu'un",
         admin: true
       }, {
         id: "2",
+        imageId: "1",
         name: "Jean-Michel Personne",
         roleLabel: "Red shirt",
         roleIcon: "mdi-cog",
         admin: false
       }, {
         id: "3",
-        name: "Juano Alphonso Santos de la Cruz de la Balina",
+        imageId: "1",
+        name: "Maxence-Louis Charles-Edouard Lancelot Meniolles d'Hautuille de la Bintinaye de Saint Hugues de Montparnasse",
         roleLabel: "User",
         roleIcon: "mdi-account-outline",
         admin: false
@@ -78,7 +81,7 @@ export const Imageless: Story = {
         admin: false
       }, {
         id: "3",
-        name: "Juano Alphonso Santos de la Cruz de la Balina",
+        name: "Maxence-Louis Charles-Edouard Lancelot Meniolles d'Hautuille de la Bintinaye de Saint Hugues de Montparnasse",
         roleLabel: "User",
         roleIcon: "mdi-account-outline",
         admin: false

--- a/src/shared/foundation-shared-components/components/FSCard.vue
+++ b/src/shared/foundation-shared-components/components/FSCard.vue
@@ -105,7 +105,7 @@ export default defineComponent({
     const { getColors, getGradients } = useColors();
 
     const colors = computed(() => {
-      if(Array.isArray(props.color)) {
+      if (Array.isArray(props.color)) {
         return getColors(props.color[0]);
       }
       return getColors(props.color);
@@ -114,6 +114,23 @@ export default defineComponent({
     const backgrounds = getColors(ColorEnum.Background);
     const lights = getColors(ColorEnum.Light);
     const darks = getColors(ColorEnum.Dark);
+
+    const borderColor = computed((): ColorBase => {
+      switch (props.variant) {
+        case "background":
+          return lights.dark;
+        case "standard"  :
+          if (Array.isArray(props.color)) {
+            return colors.value.lightContrast!;
+          }
+          if (([ColorEnum.Background, ColorEnum.Light, ColorEnum.Dark] as ColorBase[]).includes(props.color)) {
+            return lights.dark;
+          }
+          return colors.value.lightContrast!;
+        case "full"      : return colors.value.base;
+        case "gradient"  : return colors.value.lightContrast!;
+      }
+    });
 
     const style = computed((): StyleValue => {
       switch (props.variant) {
@@ -125,7 +142,7 @@ export default defineComponent({
           "--fs-card-height"          : sizeToVar(props.height),
           "--fs-card-width"           : sizeToVar(props.width),
           "--fs-card-background-color": backgrounds.base,
-          "--fs-card-border-color"    : lights.dark,
+          "--fs-card-border-color"    : borderColor.value,
           "--fs-card-color"           : darks.base
         }
         case "standard": return {
@@ -136,7 +153,7 @@ export default defineComponent({
           "--fs-card-height"          : sizeToVar(props.height),
           "--fs-card-width"           : sizeToVar(props.width),
           "--fs-card-background-color": colors.value.light,
-          "--fs-card-border-color"    : colors.value.lightContrast!,
+          "--fs-card-border-color"    : borderColor.value,
           "--fs-card-color"           : colors.value.lightContrast!
         }
         case "full": return {
@@ -147,7 +164,7 @@ export default defineComponent({
           "--fs-card-height"          : sizeToVar(props.height),
           "--fs-card-width"           : sizeToVar(props.width),
           "--fs-card-background-color": colors.value.base,
-          "--fs-card-border-color"    : colors.value.base,
+          "--fs-card-border-color"    : borderColor.value,
           "--fs-card-color"           : colors.value.baseContrast!
         }
         case "gradient": return {
@@ -158,7 +175,7 @@ export default defineComponent({
           "--fs-card-height"          : sizeToVar(props.height),
           "--fs-card-width"           : sizeToVar(props.width),
           "--fs-card-background-color": gradients.value.base,
-          "--fs-card-border-color"    : colors.value.lightContrast!,
+          "--fs-card-border-color"    : borderColor.value,
           "--fs-card-color"           : colors.value.lightContrast!
         }
       }

--- a/src/shared/foundation-shared-components/components/FSIconCard.vue
+++ b/src/shared/foundation-shared-components/components/FSIconCard.vue
@@ -58,7 +58,7 @@ export default defineComponent({
     iconColor: {
       type: String as PropType<ColorBase>,
       required: false,
-      default: ColorEnum.Primary
+      default: ColorEnum.Dark
     },
     iconVariant: {
       type: String as PropType<"base" | "baseContrast" | "soft" | "softContrast" | "light" | "lightContrast" | "dark" | "darkContrast">,

--- a/src/shared/foundation-shared-components/components/tiles/FSSimpleTileUI.vue
+++ b/src/shared/foundation-shared-components/components/tiles/FSSimpleTileUI.vue
@@ -44,7 +44,7 @@
           v-else-if="$props.icon"
           :backgroundVariant="$props.iconBackgroundVariant"
           :backgroundColor="$props.iconBackgroundColor"
-          :iconColor="$props.activeColor"
+          :iconColor="$props.iconColor"
           :border="$props.iconBorder"
           :icon="$props.icon"
           :size="imageSize"
@@ -111,6 +111,11 @@ export default defineComponent({
       type: Boolean as PropType<boolean>,
       required: false,
       default: true
+    },
+    iconColor: {
+      type: String as PropType<ColorBase>,
+      required: false,
+      default: ColorEnum.Dark
     },
     activeColor: {
       type: String as PropType<ColorBase>,


### PR DESCRIPTION
Pour remettre le ColorEnum.Dark par défaut dans la FSIconCard

J'ai aussi séparé la couleur de l'icône de la couleur au click sur les tuiles vu que ce n'est pas forcément la même mais François va changer le comportement des tuiles notamment au niveau des couleurs

Les cards de couleur dark ou background avaient des bordures trop sombres par rapport aux maquettes donc j'ai changé ça aussi pour une version plus light

Les stories des FSUserOrganisationTileUI n'affichaient pas du tout ce qu'elles auraient dû donc j'ai corrigé