### PR TITLE
Add check of FSDataTable displayed items when new items are added

### DIFF
--- a/dev/storybook/src/mocks/groups.mock.ts
+++ b/dev/storybook/src/mocks/groups.mock.ts
@@ -56,10 +56,10 @@ const getParentId = (id: string) => {
     }
 }
 
-export const GROUPS: GroupInfosDTO[] = Array.from(Array(15).keys()).map(i => ({
+export const GROUPS: GroupInfosDTO[] = Array.from(Array(80).keys()).map(i => ({
     id: (i + 1).toString(),
     organisationId: ORGANISATIONS[0].id,
-    imageId: "1",
+    imageId: null,
     icon: `mdi-numeric-${(i + 1)}-circle`,
     code: `number.${(i + 1)}`,
     label: `Group ${(i + 1)}`,

--- a/src/core/foundation-core-components/components/lists/FSDataTable.vue
+++ b/src/core/foundation-core-components/components/lists/FSDataTable.vue
@@ -1,6 +1,6 @@
 <template>
   <FSLoadDataTable
-    v-if="($props.tableCode && !initialized) || gettingUserOrganisationTable"
+    v-if="($props.tableCode && !initialized) || gettingUserOrganisationTable || !table"
   />
   <FSDataTableUI
     v-else
@@ -89,8 +89,8 @@ export default defineComponent({
       }
     }, { immediate: true });
 
-    watch(() => table.value, () => {
-      if (table.value && initialized.value) {
+    watch(() => (table.value ? { ...table.value } : null), (_, former) => {
+      if (table.value && former && initialized.value) {
         debounce(update, props.debounceTime);
       }
     }, { deep: true });

--- a/src/core/foundation-core-services/composables/services/useDataTables.ts
+++ b/src/core/foundation-core-services/composables/services/useDataTables.ts
@@ -6,23 +6,15 @@ import { type FSDataTable, type FSDataTableColumn } from "@dative-gpi/foundation
 export const useDataTables = () => {
   const initialized = ref(false);
 
-  const table = ref<FSDataTable>({
-    headers: [],
-    mode: null,
-    sortBy: null,
-    rowsPerPage: 10,
-    showFilters: false,
-    filters: {},
-    page: 1
-  });
+  const table = ref<FSDataTable | null>(null);
 
   const computeTable = (
     headersOptions: { [key: string]: Partial<FSDataTableColumn> },
     defaultMode: "table" | "iterator" = "table"
   ) => ({
     ...table.value,
-    mode: table.value.mode ?? defaultMode,
-    headers: table.value.headers.map(header => ({
+    mode: table.value?.mode ?? defaultMode,
+    headers: table.value?.headers.map(header => ({
       ...header,
       fixedFilters: (header.value && headersOptions[header.value] && headersOptions[header.value].fixedFilters) || null,
       methodFilter: (header.value && headersOptions[header.value] && headersOptions[header.value].methodFilter) || null,
@@ -61,10 +53,13 @@ export const useDataTables = () => {
     tableCode: string,
     defaultMode: "table" | "iterator" = "table"
   ): Promise<void> => {
+    let done = false;
     if (tableCode) {
       const composableTable = getTable(tableCode);
+
       if (composableTable) {
         table.value = composableTable;
+        done = true;
       }
       else {
         try {
@@ -82,12 +77,24 @@ export const useDataTables = () => {
               filters: {},
               page: 1
             }
+            done = true;
           }
         }
         catch {
           // Do nothing
         }
       }
+    }
+    if (!done) {
+      table.value = {
+        headers: [],
+        mode: null,
+        sortBy: null,
+        rowsPerPage: 10,
+        showFilters: false,
+        filters: {},
+        page: 1
+      };
     }
     initialized.value = true;
   };

--- a/src/shared/foundation-shared-components/components/lists/FSDataTableUI.vue
+++ b/src/shared/foundation-shared-components/components/lists/FSDataTableUI.vue
@@ -1344,6 +1344,7 @@ export default defineComponent({
             }, { threshold: [0.9] });
           }
           if (document.querySelector(`#${elementId}`)) {
+            intersectionObserver.value.unobserve(document.querySelector(`#${elementId}`)!);
             intersectionObserver.value.observe(document.querySelector(`#${elementId}`)!);
           }
           return;
@@ -1516,6 +1517,10 @@ export default defineComponent({
         .some((key) => filters.value[key].some((filter) => filter.hidden));
     }, { deep: true });
 
+    watch(size, () => {
+      observeIntersection();
+    });
+
     watch(innerMode, () => {
       emit("update:mode", innerMode.value);
       size.value = props.sizeIterator;
@@ -1545,10 +1550,6 @@ export default defineComponent({
         innerPage.value = 1;
         await nextTick();
         innerPage.value = formerPage;
-      }
-      if (intersectionObserver.value && document.querySelector(`#${elementId}`)) {
-        intersectionObserver.value.unobserve(document.querySelector(`#${elementId}`)!);
-        intersectionObserver.value.observe(document.querySelector(`#${elementId}`)!);
       }
     });
 


### PR DESCRIPTION
Le problème venait du fait que la vérification n'était pas déclenchée lorsque les items d'une liste était mis à jour.
Visible sur les charts puisque les tuiles sont plus petites et permettent d'en afficher 20 sur un seul écran beaucoup plus facilement que les autres entités, où l'apparation de 20 items ou plus forçait le scroll.

Fix : On force l'intersectionObserver à se déclencher pour vérifier que la div est visible en cas de changement des items de la table