### PR TITLE
Perhaps better...

### DIFF
--- a/src/shared/foundation-shared-components/components/FSDialog.vue
+++ b/src/shared/foundation-shared-components/components/FSDialog.vue
@@ -1,6 +1,7 @@
 <template>
   <v-dialog
     transition="dialog-bottom-transition"
+    :contentProps="contentProps"
     :class="classes"
     :modelValue="$props.modelValue"
     @update:modelValue="$emit('update:modelValue', $event)"
@@ -14,7 +15,6 @@
         :width="$props.width"
         :modelValue="$props.modelValue"
         @update:modelValue="$emit('update:modelValue', $event)"
-        @click.stop="$emit('click', $event)"
       >
         <template
           v-for="(_, name) in $slots"
@@ -70,8 +70,17 @@ export default defineComponent({
     }
   },
   emits: ["click", "update:modelValue"],
-  setup() {
+  setup(_, { emit }) {
     const { isExtraSmall } = useBreakpoints();
+
+    const contentProps = computed((): { [key: string]: any } => ({
+      onClick: (event: any): void => {
+        if (event.target.className != "v-overlay__content") {
+          event.stopPropagation();
+          emit("click", event);
+        }
+      }
+    }));
 
     const classes = computed((): string[] => {
       const classNames: string[] = [];
@@ -85,6 +94,7 @@ export default defineComponent({
     });
 
     return {
+      contentProps,
       classes
     };
   }


### PR DESCRIPTION
Je sais pas si c'est mieux pour toi. J'ai pas accès au composants sous le v-dialog en fait et c'est l'un des deux qui a besoin d'être cliqué pour fermer le dialogue. Du coup j'ai mis le click.stop dans le props contentProps et ça permet de s'assurer du bon fonctionnement sans avoir à mettre manuellement le click.stop si on utilise pas les slots du FSDialog.

Mais sur le principe ça change pas le fonctionnement parce que le click.self sur le v-dialog ne fonctionne pas non plus.

A toi de me dire ce que tu préfères.

> Sinon y'a un props attach sur le v-dialog et on peut lui passer window.top.document.body pour attacher le v-dialog au body du document parent. Je peux creuser l'idée pour voir si ça fonctionne, si oui ça serait pas mal, ça enlèverait le besoin de gérer les dialogues dans les extensions

My bad on a pas accès au window.top.document.body pour des raisons de cross-origin