### PR TITLE
Add possibility to give an epoch to getMachineOffset to get the offset at this point in time. Use it in epochToISO

### DIFF
--- a/src/shared/foundation-shared-components/components/calendar/FSSimpleCalendar.vue
+++ b/src/shared/foundation-shared-components/components/calendar/FSSimpleCalendar.vue
@@ -73,7 +73,7 @@ export default defineComponent({
 
     const firstDayOfMonth = computed(() => {
       const date = new Date(props.year, props.month - 1, 1);
-      const offset = getMachineOffset();
+      const offset = getMachineOffset(date.getTime());
 
       date.setTime(date.getTime() + offset);
 
@@ -84,8 +84,7 @@ export default defineComponent({
       const day = new Date(firstDayOfMonth.value);
       
       const date = startOfWeek(day, { weekStartsOn: 1 });
-
-      const offset = getMachineOffset();
+      const offset = getMachineOffset(date.getTime());
 
       date.setTime(date.getTime() + offset);
 
@@ -94,10 +93,9 @@ export default defineComponent({
 
     const endDayOfMonth = computed(() => {
       const day = new Date(firstDayOfMonth.value);
-      
-      const date = endOfMonth(day);
 
-      const offset = getMachineOffset();
+      const date = endOfMonth(day);
+      const offset = getMachineOffset(date.getTime());
 
       date.setTime(date.getTime() + offset);
 
@@ -106,10 +104,9 @@ export default defineComponent({
 
     const lastSunday = computed(() => {
       const day = new Date(endDayOfMonth.value);
-      
-      const date = endOfWeek(day, { weekStartsOn: 1 });
 
-      const offset = getMachineOffset();
+      const date = endOfWeek(day, { weekStartsOn: 1 });
+      const offset = getMachineOffset(date.getTime());
 
       date.setTime(date.getTime() + offset);
 
@@ -143,7 +140,6 @@ export default defineComponent({
       dayLabel,
       days
     };
-    
   }
 });
 </script>

--- a/src/shared/foundation-shared-services/composables/app/useAppTimeZone.ts
+++ b/src/shared/foundation-shared-services/composables/app/useAppTimeZone.ts
@@ -39,8 +39,8 @@ export const useAppTimeZone = () => {
 
   const getMachineOffsetName = (epoch: number | null = null): string => {
     const formatter = getMachineFormatter();
-    const currentDate = formatter.formatToParts(epoch ? new Date(epoch) : new Date());
-    const timeZoneName = currentDate.find((part) => part.type === "timeZoneName")?.value || "UTC+00:00";
+    const date = formatter.formatToParts(epoch ? new Date(epoch) : new Date());
+    const timeZoneName = date.find((part) => part.type === "timeZoneName")?.value || "UTC+00:00";
     return timeZoneName;
   };
 

--- a/src/shared/foundation-shared-services/composables/app/useAppTimeZone.ts
+++ b/src/shared/foundation-shared-services/composables/app/useAppTimeZone.ts
@@ -37,15 +37,15 @@ export const useAppTimeZone = () => {
     return (parseInt(hours) * 60 + parseInt(minutes)) * 60 * 1000;
   };
 
-  const getMachineOffsetName = (): string => {
+  const getMachineOffsetName = (epoch: number | null = null): string => {
     const formatter = getMachineFormatter();
-    const currentDate = formatter.formatToParts(new Date());
+    const currentDate = formatter.formatToParts(epoch ? new Date(epoch) : new Date());
     const timeZoneName = currentDate.find((part) => part.type === "timeZoneName")?.value || "UTC+00:00";
     return timeZoneName;
   };
 
-  const getMachineOffset = (): number => {
-    const timeZoneName = getMachineOffsetName();
+  const getMachineOffset = (epoch: number | null = null): number => {
+    const timeZoneName = getMachineOffsetName(epoch);
     const [hours, minutes] = timeZoneName.slice(3).split(':');
     if (isNaN(parseInt(hours)) || isNaN(parseInt(minutes))) {
       return 0;

--- a/src/shared/foundation-shared-services/composables/useDateFormat.ts
+++ b/src/shared/foundation-shared-services/composables/useDateFormat.ts
@@ -174,7 +174,8 @@ export const useDateFormat = () => {
   };
 
   const yesterdayToPicker = (): string => {
-    const date = addMilliseconds(subDays(new Date(), 1), -getMachineOffset());
+    const yesterday = subDays(new Date(), 1);
+    const date = addMilliseconds(yesterday, -getMachineOffset(yesterday.getTime()));
     date.setSeconds(0, 0);
     return format(date, ISO_FORMAT);
   };
@@ -187,9 +188,9 @@ export const useDateFormat = () => {
     return date.getTime();
   };
 
-  const epochToISO = (date: number | null): string => {
-    if (date != null) {
-      return format(date - getMachineOffset(date), ISO_FORMAT);
+  const epochToISO = (epoch: number | null): string => {
+    if (epoch != null) {
+      return format(epoch - getMachineOffset(epoch), ISO_FORMAT);
     }
     return "";
   };

--- a/src/shared/foundation-shared-services/composables/useDateFormat.ts
+++ b/src/shared/foundation-shared-services/composables/useDateFormat.ts
@@ -189,7 +189,7 @@ export const useDateFormat = () => {
 
   const epochToISO = (date: number | null): string => {
     if (date != null) {
-      return format(date - getMachineOffset(), ISO_FORMAT);
+      return format(date - getMachineOffset(date), ISO_FORMAT);
     }
     return "";
   };


### PR DESCRIPTION
Même fix que pour le FSDateTimeField / FSDateTimeRangeField mais cette fois pour epochToISO

Le epochToISO ne prenait pas en compte l'offset à la date qu'on veut traduire mais l'offset actuel, posant problème sur les time zones avec changement d'heure