### PR TITLE
Sort after event

### DIFF
--- a/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
+++ b/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
@@ -235,13 +235,14 @@ export default defineComponent({
     const search = ref("");
 
     const deviceExplorerElements = computed((): DeviceExplorerElementInfos[] => {
+      let elements = entities.value.slice();
       if (props.connectedOnly) {
-        return entities.value.filter(dee => 
+        elements = elements.filter(dee => 
           dee.type === DeviceExplorerElementType.Group ||
           (dee.connectivity != null && dee.connectivity.status != ConnectivityStatus.None)
         );
       }
-      return entities.value;
+      return elements.sort((a, b) => a.type - b.type);
     });
 
     const isSelected = (id: string): boolean => {

--- a/src/core/foundation-core-services/composables/services/useDeviceExplorerElements.ts
+++ b/src/core/foundation-core-services/composables/services/useDeviceExplorerElements.ts
@@ -3,6 +3,7 @@ import { ref } from "vue";
 import { DeviceExplorerElementDetails, type DeviceExplorerElementDetailsDTO, type DeviceExplorerElementFilters, DeviceExplorerElementInfos, type DeviceExplorerElementInfosDTO, type DeviceOrganisationDetails, type GroupDetails } from "@dative-gpi/foundation-core-domain/models";
 import { type AddOrUpdateCallback, type DeleteCallback, type NotifyEvent, onCollectionChanged } from "@dative-gpi/bones-ui";
 import { fromDeviceOrganisation, fromGroup } from "@dative-gpi/foundation-shared-domain/tools";
+import { alphanumericSort } from "@dative-gpi/foundation-shared-components/utils";
 import { ServiceFactory } from "@dative-gpi/bones-ui/core";
 
 import { DEVICE_EXPLORER_ELEMENTS_URL } from "../../config/urls";
@@ -48,7 +49,16 @@ export const useDeviceExplorerElements = () => {
         (fullText.toLowerCase().includes(filters.value.search.toLowerCase()));
     };
 
-    const onCollectionChangedCustom = onCollectionChanged(entities, filterMethod) ;
+    const sortMethod = (): void => {
+      entities.value = entities.value.sort((a, b) => {
+        if (a.type === b.type) {
+          return alphanumericSort(a.label, b.label);
+        }
+        return a.type - b.type;
+      });
+    };
+
+    const onCollectionChangedCustom = onCollectionChanged(entities, filterMethod);
 
     try {
       entities.value = await DeviceExplorerElementServiceFactory.getMany(filters.value);
@@ -63,6 +73,7 @@ export const useDeviceExplorerElements = () => {
             (onCollectionChangedCustom as DeleteCallback)(ev, el);
             break;
         }
+        sortMethod();
       });
 
       subscribeToGroups("all", (ev: NotifyEvent, el: GroupDetails | any) => {
@@ -75,6 +86,7 @@ export const useDeviceExplorerElements = () => {
             (onCollectionChangedCustom as DeleteCallback)(ev, el);
             break;
         }
+        sortMethod();
       });
 
       watchDevicesStatuses();

--- a/src/core/foundation-core-services/composables/services/useDeviceExplorerElements.ts
+++ b/src/core/foundation-core-services/composables/services/useDeviceExplorerElements.ts
@@ -3,7 +3,6 @@ import { ref } from "vue";
 import { DeviceExplorerElementDetails, type DeviceExplorerElementDetailsDTO, type DeviceExplorerElementFilters, DeviceExplorerElementInfos, type DeviceExplorerElementInfosDTO, type DeviceOrganisationDetails, type GroupDetails } from "@dative-gpi/foundation-core-domain/models";
 import { type AddOrUpdateCallback, type DeleteCallback, type NotifyEvent, onCollectionChanged } from "@dative-gpi/bones-ui";
 import { fromDeviceOrganisation, fromGroup } from "@dative-gpi/foundation-shared-domain/tools";
-import { alphanumericSort } from "@dative-gpi/foundation-shared-components/utils";
 import { ServiceFactory } from "@dative-gpi/bones-ui/core";
 
 import { DEVICE_EXPLORER_ELEMENTS_URL } from "../../config/urls";
@@ -49,15 +48,6 @@ export const useDeviceExplorerElements = () => {
         (fullText.toLowerCase().includes(filters.value.search.toLowerCase()));
     };
 
-    const sortMethod = (): void => {
-      entities.value = entities.value.sort((a, b) => {
-        if (a.type === b.type) {
-          return alphanumericSort(a.label, b.label);
-        }
-        return a.type - b.type;
-      });
-    };
-
     const onCollectionChangedCustom = onCollectionChanged(entities, filterMethod);
 
     try {
@@ -73,7 +63,6 @@ export const useDeviceExplorerElements = () => {
             (onCollectionChangedCustom as DeleteCallback)(ev, el);
             break;
         }
-        sortMethod();
       });
 
       subscribeToGroups("all", (ev: NotifyEvent, el: GroupDetails | any) => {
@@ -86,7 +75,6 @@ export const useDeviceExplorerElements = () => {
             (onCollectionChangedCustom as DeleteCallback)(ev, el);
             break;
         }
-        sortMethod();
       });
 
       watchDevicesStatuses();


### PR DESCRIPTION
Tri des DeviceExplorerElements après un add / update / delete.

Le tri appliqué est celui des repo par défaut, mais il est override par celui de la table.
Il permet de mettre un groupe ou un équipement à la bonne place lorsque celui ci est ajouté / modifié si l'explorateur n'es pas trié, afin de coller à ce qui est obtenu depuis le back