### PR TITLE
Remove root in recursive search

### DIFF
--- a/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
+++ b/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
@@ -270,7 +270,6 @@ export default defineComponent({
       if (props.recursiveSearch && search.value) {
         getManyDeviceExplorerElements({
           ancestorId: props.parentId,
-          root: props.root,
           search: search.value
         });
       }


### PR DESCRIPTION
Si root dans le filtre pendant la recherche récursive -> ça ne marchera pas puisque les petit-enfants ne sont pas à la racine

Et si on recherche depuis la racine -> ça marchera même sans root puisque qu'il faut tout considérer