### PR TITLE
Fix date field minWidth

### DIFF
--- a/src/shared/foundation-shared-components/components/fields/FSDateField.vue
+++ b/src/shared/foundation-shared-components/components/fields/FSDateField.vue
@@ -72,6 +72,7 @@
       v-else
     >
       <v-menu
+        min-width="300px"
         :closeOnContentClick="false"
         :modelValue="menu && $props.editable"
         @update:modelValue="menu = $event"


### PR DESCRIPTION
Make the date field overlay smaller than 100% to be able to click at its right side to close it