### PR TITLE
Better ellipsis handling in texts

### DIFF
--- a/src/shared/foundation-shared-components/components/FSSpan.vue
+++ b/src/shared/foundation-shared-components/components/FSSpan.vue
@@ -1,13 +1,15 @@
 <template>
-  <span
+  <div
     :class="classes"
     :style="style"
     v-bind="$attrs"
   >
-    <slot>
-      {{ $props.label }}
-    </slot>
-  </span>
+    <span>
+      <slot>
+        {{ $props.label }}
+      </slot>
+    </span>
+  </div>
 </template>
 
 <script lang="ts">
@@ -49,6 +51,7 @@ export default defineComponent({
     const { slots } = useSlots();
 
     const style = computed((): StyleValue => ({
+      "--fs-span-text-align": props.align,
       "--fs-span-line-clamp": props.lineClamp.toString(),
       ...fontStyles.value
     }));

--- a/src/shared/foundation-shared-components/components/FSText.vue
+++ b/src/shared/foundation-shared-components/components/FSText.vue
@@ -1,13 +1,15 @@
 <template>
-  <span
+  <div
     :class="classes"
     :style="style"
     v-bind="$attrs"
   >
-    <slot>
-      {{ $props.label }}
-    </slot>
-  </span>
+    <span>
+      <slot>
+        {{ $props.label }}
+      </slot>
+    </span>
+  </div>
 </template>
 
 <script lang="ts">

--- a/src/shared/foundation-shared-components/styles/components/fs_span.scss
+++ b/src/shared/foundation-shared-components/styles/components/fs_span.scss
@@ -1,9 +1,9 @@
-.fs-span {
+.fs-span > span {
+    text-align: var(--fs-span-text-align);
     max-width: 100%;
-    text-align: left;
 }
 
-.fs-span-line-clamp {
+.fs-span-line-clamp > span {
     overflow: hidden;
     display: -webkit-box;
     line-clamp: var(--fs-span-line-clamp);
@@ -11,12 +11,21 @@
     -webkit-line-clamp: var(--fs-span-line-clamp);
 }
 
-.fs-span-ellipsis {
+.fs-span-ellipsis > span {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
 }
 
-.fs-span-pre-wrap {
+.fs-span-pre-wrap > span {
     white-space: pre-wrap;
+}
+
+.fs-span {
+    align-self: stretch;
+    display: flex;
+    flex: 1 0 0;
+
+    max-width: fit-content;
+    min-width: 0;
 }


### PR DESCRIPTION
FSText et FSSpan sont contraints par défaut dans un FSRow afin de gérer l'ellipsis correctement sans aide extérieure.

Un FSText ou un FSSpan qui sont les enfants directs d'une FSCol ont néanmoins besoin que la FSCol soit contrainte (Typiquement: min-width: 0 suffit) pour gérer leur ellipsis