### PR TITLE
Fixes/devices latency

### DIFF
--- a/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
+++ b/src/core/foundation-core-components/components/explorers/FSBaseDevicesExplorer.vue
@@ -129,28 +129,38 @@
     </template>
 
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSGroupTileUI
         v-if="item.type === DeviceExplorerElementType.Group"
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
+        :imageId="item.imageId"
+        :icon="item.icon"
+        :label="item.label"
+        :code="item.code"
+        :recursiveGroupsIds="item.recursiveGroupsIds"
+        :recursiveDeviceOrganisationsIds="item.recursiveDeviceOrganisationsIds"
         :modelValue="isSelected(item.id)"
         :selectable="$props.selectable"
         @update:modelValue="toggleSelect(item)"
-        v-bind="item"
       />
       <FSDeviceOrganisationTileUI
         v-if="item.type === DeviceExplorerElementType.DeviceOrganisation"
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
         :deviceConnectivity="item.connectivity"
         :deviceStatuses="item.status.statuses"
         :deviceWorstAlert="item.worstAlert"
         :deviceAlerts="item.alerts"
+        :imageId="item.imageId"
+        :label="item.label"
+        :code="item.code"
+        :modelStatuses="item.modelStatuses"
         :alertTo="$props.alertTo"
         :modelValue="isSelected(item.id)"
         :selectable="$props.selectable"
         @update:modelValue="toggleSelect(item)"
-        v-bind="item"
       />
     </template>
   </FSDataTable>

--- a/src/core/foundation-core-components/components/explorers/FSBaseFoldersExplorer.vue
+++ b/src/core/foundation-core-components/components/explorers/FSBaseFoldersExplorer.vue
@@ -90,10 +90,11 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSFolderTileUI
         v-if="item.type == FoldersListType.Folder"
+        :key="index"
         :bottomColor="item.colors"
         v-bind="item"
         :selectable="$props.selectable"
@@ -103,6 +104,7 @@
       />
       <FSDashboardOrganisationTileUI
         v-if="item.type == FoldersListType.Dashboard && item.dashboardType == DashboardType.Organisation"
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :modelValue="isSelected(item.id)"
@@ -112,6 +114,7 @@
       />
       <FSDashboardShallowTileUI
         v-if="item.type == FoldersListType.Dashboard && item.dashboardType == DashboardType.Shallow"
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :modelValue="isSelected(item.id)"

--- a/src/core/foundation-core-components/components/lists/alerts/FSBaseAlertsList.vue
+++ b/src/core/foundation-core-components/components/lists/alerts/FSBaseAlertsList.vue
@@ -171,9 +171,10 @@
       </FSSpan>
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSAlertTileUI
+        :key="index"
         variant="standard"
         :label="item.label"
         :deviceOrganisationLabel="item.deviceOrganisationLabel"

--- a/src/core/foundation-core-components/components/lists/chartOrganisationTypes/FSBaseChartOrganisationTypesList.vue
+++ b/src/core/foundation-core-components/components/lists/chartOrganisationTypes/FSBaseChartOrganisationTypesList.vue
@@ -79,9 +79,10 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect}"
+      #item.tile="{ index, item, toggleSelect}"
     >
       <FSChartTileUI
+        :key="index"
         :label="item.label"
         :category-label="item.chartCategoryLabel"
         :singleSelect="$props.singleSelect"

--- a/src/core/foundation-core-components/components/lists/chartOrganisations/FSBaseChartOrganisationsList.vue
+++ b/src/core/foundation-core-components/components/lists/chartOrganisations/FSBaseChartOrganisationsList.vue
@@ -79,9 +79,10 @@
       </FSRow>
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSChartTileUI
+        :key="index"
         :label="item.label"
         :singleSelect="$props.singleSelect"
         :selectable="$props.selectable"

--- a/src/core/foundation-core-components/components/lists/charts/FSBaseChartsList.vue
+++ b/src/core/foundation-core-components/components/lists/charts/FSBaseChartsList.vue
@@ -85,9 +85,10 @@
       />
     </template>
     <template
-      #item.tile="{ item }"
+      #item.tile="{ index, item }"
     >
       <FSChartTileUI
+        :key="index"
         :label="item.label"
         :categoryLabel="item.chartCategoryLabel"
         :icon="item.icon"

--- a/src/core/foundation-core-components/components/lists/dashboardOrganisationTypes/FSBaseDashboardOrganisationTypesList.vue
+++ b/src/core/foundation-core-components/components/lists/dashboardOrganisationTypes/FSBaseDashboardOrganisationTypesList.vue
@@ -66,9 +66,10 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSDashboardOrganisationTypeTileUI
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :singleSelect="$props.singleSelect"

--- a/src/core/foundation-core-components/components/lists/dashboards/FSBaseDashboardsList.vue
+++ b/src/core/foundation-core-components/components/lists/dashboards/FSBaseDashboardsList.vue
@@ -60,10 +60,11 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSDashboardOrganisationTypeTileUI
         v-if="item.dashboardType == DashboardType.OrganisationType"
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :singleSelect="$props.singleSelect"
@@ -74,6 +75,7 @@
       />
       <FSDashboardOrganisationTileUI
         v-if="item.dashboardType == DashboardType.Organisation"
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :singleSelect="$props.singleSelect"
@@ -84,6 +86,7 @@
       />
       <FSDashboardShallowTileUI
         v-if="item.dashboardType == DashboardType.Shallow"
+        :key="index"
         :bottomColor="item.colors"
         :selectable="$props.selectable"
         :singleSelect="$props.singleSelect"

--- a/src/core/foundation-core-components/components/lists/dataCategories/FSBaseDataCategoriesList.vue
+++ b/src/core/foundation-core-components/components/lists/dataCategories/FSBaseDataCategoriesList.vue
@@ -39,9 +39,10 @@
           />
         </template>
         <template
-          #item.tile="{ item }"
+          #item.tile="{ index, item }"
         >
           <FSClickable
+            :key="index"
             padding="12px"
             height="60px"
             width="233px"

--- a/src/core/foundation-core-components/components/lists/dataDefinitions/FSBaseDataDefinitionsList.vue
+++ b/src/core/foundation-core-components/components/lists/dataDefinitions/FSBaseDataDefinitionsList.vue
@@ -26,9 +26,10 @@
       />
     </template>
     <template
-      #item.tile="{ item }"
+      #item.tile="{ index, item }"
     >
       <FSClickable
+        :key="index"
         padding="12px"
         height="60px"
         width="233px"

--- a/src/core/foundation-core-components/components/lists/deviceOrganisations/FSBaseDeviceOrganisationsList.vue
+++ b/src/core/foundation-core-components/components/lists/deviceOrganisations/FSBaseDeviceOrganisationsList.vue
@@ -138,9 +138,10 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSDeviceOrganisationTileUI
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
         :selectable="$props.selectable"
         :deviceConnectivity="item.connectivity"

--- a/src/core/foundation-core-components/components/lists/folders/FSBaseFoldersList.vue
+++ b/src/core/foundation-core-components/components/lists/folders/FSBaseFoldersList.vue
@@ -37,9 +37,10 @@
     </template>
 
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSFolderTileUI
+        :key="index"
         :bottomColor="item.colors"
         v-bind="item"
         :modelValue="isSelected(item.id)"

--- a/src/core/foundation-core-components/components/lists/groups/FSBaseGroupsList.vue
+++ b/src/core/foundation-core-components/components/lists/groups/FSBaseGroupsList.vue
@@ -53,9 +53,10 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSGroupTileUI
+        :key="index"
         :selectable="$props.selectable"
         :modelValue="isSelected(item.id)"
         @update:modelValue="toggleSelect(item)"

--- a/src/core/foundation-core-components/components/lists/locations/FSBaseLocationsList.vue
+++ b/src/core/foundation-core-components/components/lists/locations/FSBaseLocationsList.vue
@@ -27,10 +27,10 @@
     </template>
 
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSLocationTileUI
-        v-bind="item"
+        :key="index"
         :bottomColor="item.colors"
         :address="item.address.placeLabel"
         :selectable="$props.selectable"
@@ -38,6 +38,7 @@
         :modelValue="isSelected(item.id)"
         :to="$props.itemTo && $props.itemTo(item)"
         @update:modelValue="toggleSelect(item)"
+        v-bind="item"
       />
     </template>
   </FSDataTable>

--- a/src/core/foundation-core-components/components/lists/models/FSBaseModelsList.vue
+++ b/src/core/foundation-core-components/components/lists/models/FSBaseModelsList.vue
@@ -59,9 +59,10 @@
       />
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSModelTileUI
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
         :selectable="$props.selectable"
         :singleSelect="$props.singleSelect"

--- a/src/core/foundation-core-components/components/lists/serviceAccountOrganisations/FSBaseServiceAccountOrganisationsList.vue
+++ b/src/core/foundation-core-components/components/lists/serviceAccountOrganisations/FSBaseServiceAccountOrganisationsList.vue
@@ -64,9 +64,10 @@
       </FSSpan>
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSServiceAccountOrganisationTileUI
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
         :selectable="$props.selectable"
         :modelValue="isSelected(item.id)"

--- a/src/core/foundation-core-components/components/lists/userOrganisations/FSBaseUserOrganisationsList.vue
+++ b/src/core/foundation-core-components/components/lists/userOrganisations/FSBaseUserOrganisationsList.vue
@@ -78,9 +78,10 @@
       </FSSpan>
     </template>
     <template
-      #item.tile="{ item, toggleSelect }"
+      #item.tile="{ index, item, toggleSelect }"
     >
       <FSUserOrganisationTileUI
+        :key="index"
         :to="$props.itemTo && $props.itemTo(item)"
         :selectable="$props.selectable"
         :modelValue="isSelected(item.id)"


### PR DESCRIPTION
- Le slot #item-tile des FSDataTable on un index qui n'était pas passé à nos tiles 
- Pour le FSBaseDevicesExplorer on utilisé v-bind="item" sauf que les items on une propriété "type" qui déscendait jusqu'au FSClickable qui n'était pas content

J'ai créé un tag et tester sur Foundation et je n'arrive pas à reproduire la latence extrême qu'il y avait, j'ai du mal a comprendre ce que ça a pu changer mais le navigateur n'a plus l'air d'être dans les choux 